### PR TITLE
Use single download function

### DIFF
--- a/cmd/helm-keyvault/main.go
+++ b/cmd/helm-keyvault/main.go
@@ -20,6 +20,21 @@ func main() {
 	app := &cli.App{
 		Commands: []*cli.Command{
 			{
+				Name:  "download",
+				Usage: "Downlaod and decode secret from keyvault and print contents to stdout - use with helm downloader plugin",
+				Action: func(c *cli.Context) error {
+					if c.Args().Len() != 4 {
+						return errors.New("Please specify four arguments - command certFile keyFile caFile full-URL")
+					}
+					u := c.Args().Get(3)
+					if len(u) <= 0 {
+						return errors.New("full-URL argument missing")
+					}
+					return cmd.Download(u)
+
+				},
+			},
+			{
 				Name:    "secret",
 				Aliases: []string{"s"},
 				Usage:   "get secret, put secrets, download secrets as values.yaml files",
@@ -42,21 +57,6 @@ func main() {
 						}),
 						Action: func(c *cli.Context) error {
 							return cmd.PutSecret(c.String("id"), c.String("file"))
-						},
-					},
-					{
-						Name:  "download",
-						Usage: "Downlaod and decode secret from keyvault and print contents to stdout - use with helm downloader plugin",
-						Action: func(c *cli.Context) error {
-							if c.Args().Len() != 4 {
-								return errors.New("Please specify four arguments - command certFile keyFile caFile full-URL")
-							}
-							u := c.Args().Get(3)
-							if len(u) <= 0 {
-								return errors.New("Url argument missing")
-							}
-							return cmd.DownloadSecret(u)
-
 						},
 					},
 				},

--- a/internal/cmd/download.go
+++ b/internal/cmd/download.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	"fmt"
+)
+
+// DownloadSecret - Download and decode secret to be used as downloader plugin
+func Download(uri string) error {
+
+	su, err := newUri(uri[len("keyvault+"):])
+	if err != nil {
+		return err
+	}
+
+	value, err := su.download()
+	if err != nil {
+		return err
+	}
+	fmt.Print(value)
+	return nil
+}

--- a/internal/cmd/secret.go
+++ b/internal/cmd/secret.go
@@ -2,44 +2,26 @@ package cmd
 
 import (
 	"encoding/base64"
-	"encoding/json"
 	"fmt"
-	"github.com/foryouandyourcustomers/helm-keyvault/internal/keyvault"
 	"io/ioutil"
-	"net/url"
-	"strings"
 )
-
-type secretUri struct {
-	Keyvault string
-	Name     string
-	Version  string
-}
-
-func newSecretUri(uri string) (*secretUri, error) {
-	// parse the given uri
-	// keyvault://<keyvaultname>/secrets/<secretname>/<version>
-	u, err := url.Parse(uri)
-	if err != nil {
-		return &secretUri{}, err
-	}
-
-	// retrieve keyvault, secret and optional secret version from parsed uri
-	ur := secretUri{}
-	ur.Keyvault = u.Host
-	s := strings.Split(strings.Replace(u.Path, "/secrets/", "", 1), "/")
-	ur.Name = s[0]
-	ur.Version = ""
-	if len(s) == 2 {
-		ur.Version = s[1]
-	}
-	return &ur, nil
-}
 
 // GetSecret - Get secret from given keyvault
 func GetSecret(id string) error {
-	err := DownloadSecret(id)
-	return err
+
+	// parse given id into its keyvault components
+	su, err := newSecretUri(id)
+	if err != nil {
+		return err
+	}
+
+	// retrieve and decode secret content
+	value, err := su.download()
+	if err != nil {
+		return err
+	}
+	fmt.Print(value)
+	return nil
 }
 
 // PutSecret - Encode file and put secret into keyvault
@@ -47,7 +29,6 @@ func PutSecret(id string, f string) error {
 
 	// parse given id into its keyvault components
 	su, err := newSecretUri(id)
-
 	if err != nil {
 		return err
 	}
@@ -59,37 +40,11 @@ func PutSecret(id string, f string) error {
 	}
 	e := base64.StdEncoding.EncodeToString(c)
 
-	s, err := keyvault.PutSecret(su.Keyvault, su.Name, e)
+	// upload the file content'
+	value, err := su.upload(e)
 	if err != nil {
 		return err
 	}
-
-	res, err := json.Marshal(s)
-	if err != nil {
-		return err
-	}
-	fmt.Println(string(res))
-	return nil
-}
-
-// DownloadSecret - Download and decode secret to be used as downloader plugin
-func DownloadSecret(uri string) error {
-	su, err := newSecretUri(uri)
-	if err != nil {
-		return err
-	}
-
-	// get secret from keyvault and print it
-	secret, err := keyvault.GetSecret(su.Keyvault, su.Name, su.Version)
-	if err != nil {
-		return err
-	}
-
-	// decode secret and print
-	dec, err := secret.Decode()
-	if err != nil {
-		return err
-	}
-	fmt.Print(dec)
+	fmt.Print(value)
 	return nil
 }

--- a/internal/cmd/uri.go
+++ b/internal/cmd/uri.go
@@ -1,0 +1,105 @@
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"github.com/foryouandyourcustomers/helm-keyvault/internal/keyvault"
+	"net/url"
+	"strings"
+)
+
+type generalUri interface {
+	download() (string, error)
+}
+
+// secretUri - represents an keyvault+secret uri
+type secretUri struct {
+	Keyvault string
+	Name     string
+	Version  string
+}
+
+func (u *secretUri) download() (string, error) {
+
+	//get secret from keyvault and print it
+	secret, err := keyvault.GetSecret(u.Keyvault, u.Name, u.Version)
+	if err != nil {
+		return "", err
+	}
+	// decode secret and print
+	dec, err := secret.Decode()
+	if err != nil {
+		return "", err
+	}
+	return dec, nil
+}
+
+// upload - upload base64 encoded content to keyvault
+func (u *secretUri) upload(c string) (string, error) {
+
+	s, err := keyvault.PutSecret(u.Keyvault, u.Name, c)
+	if err != nil {
+		return "", err
+	}
+
+	res, err := json.Marshal(s)
+	if err != nil {
+		return "", err
+	}
+	return string(res), nil
+}
+
+type fileUri struct {
+	File string
+}
+
+func (u fileUri) download() (string, error) {
+	return "to be implemented", nil
+}
+
+func (u fileUri) upload() (string, error) {
+	return "", errors.New("not implemented")
+}
+
+func newSecretUri(uri string) (secretUri, error) {
+
+	u, err := url.Parse(uri)
+	if err != nil {
+		return secretUri{}, err
+	}
+
+	ur := secretUri{}
+	ur.Keyvault = u.Host
+	s := strings.Split(strings.Replace(u.Path, "/secrets/", "", 1), "/")
+	ur.Name = s[0]
+	ur.Version = ""
+	if len(s) == 2 {
+		ur.Version = s[1]
+	}
+	return ur, nil
+}
+
+func newFileUri(uri string) (fileUri, error) {
+	return fileUri{}, nil
+}
+
+func newUri(uri string) (generalUri, error) {
+
+	if strings.HasPrefix(uri, "secret") {
+		u, err := newSecretUri(uri)
+		if err != nil {
+			return nil, err
+		}
+		return &u, nil
+	}
+
+	if strings.HasPrefix(uri, "file") {
+		u, err := newFileUri(uri)
+		if err != nil {
+			return nil, err
+		}
+		return &u, nil
+	}
+
+	return nil, errors.New("invalid full-URL")
+}

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -48,6 +48,6 @@ ignoreFlags: false
 command: "$HELM_PLUGIN_DIR/helm-keyvault"
 
 downloaders:
-  - command: "helm-keyvault secret download"
+  - command: "helm-keyvault download"
     protocols:
       - "keyvault+secret"


### PR DESCRIPTION
The helm downloader plugin can only use
a single download function for all given uri schemes

This commit implements a single downloader function